### PR TITLE
Argument show page outline is working

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,5 @@
 // Your CSS partials
 @import "components/index";
 @import "pages/index";
+@import "components/argument_show_card";
+@import "components/button";

--- a/app/assets/stylesheets/components/_argument_show_card.scss
+++ b/app/assets/stylesheets/components/_argument_show_card.scss
@@ -1,0 +1,27 @@
+.card-product {
+  overflow: hidden;
+  height: 120px;
+  background: white;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.card-product h2 {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.card-product p {
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: .7;
+  margin-bottom: 0;
+  margin-top: 8px;
+}
+
+.card-product .card-product-infos {
+  padding: 16px;
+}

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,0 +1,3 @@
+.btn {
+  border-radius: 24px;
+}

--- a/app/assets/stylesheets/pages/_argument_show.scss
+++ b/app/assets/stylesheets/pages/_argument_show.scss
@@ -1,0 +1,12 @@
+.container {
+  text-decoration: none;
+  color: black;
+}
+
+.title {
+  margin: 8px 0;
+}
+
+#Answer {
+  margin-top: 16px;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 // Import page-specific CSS files here.
 @import "home";
+@import "argument_show";

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -2,15 +2,31 @@ class ArgumentsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show]
 
   def new
-  end
-
-  def create
     @argument = Argument.new
-    @argument.user = current_user
     authorize @argument
   end
 
+  def create
+    # raise
+    @argument = Argument.new(argument_params)
+    @argument.user = current_user
+    authorize @argument
+    if @argument.save
+      if params[:argument][:argument_id]
+        redirect_to argument_path(Argument.find(params[:argument][:argument_id]))
+      else
+        redirect_to argument_path(@argument)
+      end
+    else
+      @argument_show = Argument.find(params[:argument][:argument_id])
+      render "/arguments/show"
+    end
+  end
+
   def show
+    @argument = Argument.new
+    @argument_show = Argument.find(params[:id])
+    authorize @argument_show
   end
 
   def edit
@@ -20,5 +36,11 @@ class ArgumentsController < ApplicationController
   def update
     @argument = Argument.find(params[:id])
     authorize @argument
+  end
+
+  private
+
+  def argument_params
+    params.require(:argument).permit(:content, :source, :argument_id)
   end
 end

--- a/app/views/arguments/_form.html.erb
+++ b/app/views/arguments/_form.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for [@argument] do |f| %>
+  <%= f.input :content %>
+  <%= f.input :source %>
+  <%= f.hidden_field :argument_id, value: arg.id %>
+  <%= f.button :submit, value: "Add Argument", class: "btn btn-primary btn-lg w-100" %>
+<% end %>

--- a/app/views/arguments/show.html.erb
+++ b/app/views/arguments/show.html.erb
@@ -1,0 +1,28 @@
+<p><%= link_to "Back", "/" %></p>
+<div class="container">
+  <div class="col-12 col-md-8 d-flex justify-content-center">
+    <h1 class="title"><%= @argument_show.content %></h1>
+  </div>
+</div>
+
+<%  Argument.find_each do |a| %>
+  <% if a.argument_id == @argument_show.id %>
+    <%= link_to argument_path(a) do %>
+      <div class="container">
+        <div class="card-product">
+          <div class="card-product-infos">
+            <h2><%= a.content %></h2>
+            <p><%= a.source %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="col-12 col-md-8 d-flex justify-content-start" id="Answer">
+  <h1>Add an Answer</h1>
+</div>
+<div class="col-12 col-md-8 d-flex justify-content-start">
+  <%= render '/arguments/form', arg: @argument_show %>
+</div>

--- a/db/migrate/20201124144446_change_argument_id_to_null_true.rb
+++ b/db/migrate/20201124144446_change_argument_id_to_null_true.rb
@@ -1,0 +1,5 @@
+class ChangeArgumentIdToNullTrue < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :arguments, :argument_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_195926) do
+ActiveRecord::Schema.define(version: 2020_11_24_144446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_11_23_195926) do
     t.bigint "user_id", null: false
     t.text "content"
     t.string "source"
-    t.bigint "argument_id", null: false
+    t.bigint "argument_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["argument_id"], name: "index_arguments_on_argument_id"


### PR DESCRIPTION
Argument show page outline is up and running
"Back" link takes you to the root page currently (**need to add functionality so if it is nested it goes to the parent arg**)
Argument cards are clickable and bring you to that argument's page
Can add an answer at the bottom that will automatically be associated with the current argument
**Isn't displaying vote totals and upvote/downvote functionality right now**
**Don't have the "select an existing argument" yet**